### PR TITLE
Fix to error message when writing a file "completely fails"

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,5 @@
+   * Fix to error message when writing a file "completely fails" (Graham Barr)
+
 1.14 - 2011-01-08
 
    * support the file_debug command (dormando <dormando@rydia.net>)

--- a/lib/MogileFS/NewHTTPFile.pm
+++ b/lib/MogileFS/NewHTTPFile.pm
@@ -233,7 +233,13 @@ sub _write {
 
     # total failure (croak)
     $self->{sock} = undef;
-    _fail(sprintf("unable to write to any allocated storage node, last tried dev %s on host %s uri %s. Had sent %s bytes, %s bytes left", $self->{devid}, $self->{host}, $self->{uri}, $self->{path}, $self->{bytes_out}, $bytesleft));
+    _fail(
+        sprintf(
+            "unable to write to any allocated storage node, last tried dev %s on host %s uri %s path %s. Had sent %s bytes, %s bytes left",
+            $self->{devid}, $self->{host},      $self->{uri},
+            $self->{path},  $self->{bytes_out}, $bytesleft
+        )
+    );
 }
 
 sub PRINT {


### PR DESCRIPTION
(the sprintf string was missing an %s)
