### PR TITLE
Error handling tweaks

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -21,6 +21,7 @@ WriteMakefile(
         'LWP::Simple'     => 0,
         fields            => 0,
         'Test::More'      => 0,
+        'List::Util'      => 0,
     },
 );
 

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -188,7 +188,6 @@ sub do_request {
         $self->{'lasterr'} = $1;
         $self->{'lasterrstr'} = $2 ? _unescape_url_string($2) : undef;
         _debug("LASTERR: $1 $2");
-        undef $self->{sock_cache};
         return undef;
     }
 

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -224,7 +224,7 @@ sub err {
     return $self->{lasterr} ? 1 : 0;
 }
 
-sub force_reconnect {
+sub force_disconnect {
     my MogileFS::Backend $self = shift;
     undef $self->{sock_cache};
     return;

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -9,6 +9,7 @@ use Socket qw( MSG_NOSIGNAL PF_INET IPPROTO_TCP SOCK_STREAM );
 use Errno qw( EINPROGRESS EWOULDBLOCK EISCONN );
 use POSIX ();
 use MogileFS::Client;
+use List::Util qw/ shuffle /;
 
 use fields ('hosts',        # arrayref of "$host:$port" of mogilefsd servers
             'host_dead',    # "$host:$port" -> $time  (of last connect failure)
@@ -59,6 +60,8 @@ sub _init {
             if $args{timeout} && $args{timeout} !~ /^\d+$/;
         $self->{timeout} = $args{timeout} || 3;
     }
+
+    $self->{hosts} = [ shuffle(@{ $self->{hosts} }) ];
 
     $self->{host_dead} = {};
 

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -185,6 +185,7 @@ sub do_request {
         $self->{'lasterr'} = $1;
         $self->{'lasterrstr'} = $2 ? _unescape_url_string($2) : undef;
         _debug("LASTERR: $1 $2");
+        undef $self->{sock_cache};
         return undef;
     }
 

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -224,6 +224,12 @@ sub err {
     return $self->{lasterr} ? 1 : 0;
 }
 
+sub force_reconnect {
+    my MogileFS::Backend $self = shift;
+    undef $self->{sock_cache};
+    return;
+}
+
 ################################################################################
 # MogileFS::Backend class methods
 #

--- a/lib/MogileFS/Client.pm
+++ b/lib/MogileFS/Client.pm
@@ -185,17 +185,18 @@ sub errcode {
     return $self->{backend}->errcode;
 }
 
-=head2 force_reconnect
+=head2 force_disconnect
 
-Forces the client to reconnect to the tracker, or if possible a different
-tracker.  A paranoid application may wish to do to this before retrying a
+Forces the client to disconnect from the tracker, causing it to reconnect
+when the next request is made.  It will reconnect to a different tracker if
+possible.  A paranoid application may wish to do to this before retrying a
 failed command, on the off chance that another tracker may be working better.
 
 =cut
 
-sub force_reconnect {
+sub force_disconnect {
     my MogileFS::Client $self = shift;
-    return $self->{backend}->force_reconnect();
+    return $self->{backend}->force_disconnect();
 }
 
 =head2 readonly

--- a/lib/MogileFS/Client.pm
+++ b/lib/MogileFS/Client.pm
@@ -185,6 +185,19 @@ sub errcode {
     return $self->{backend}->errcode;
 }
 
+=head2 force_reconnect
+
+Forces the client to reconnect to the tracker, or if possible a different
+tracker.  A paranoid application may wish to do to this before retrying a
+failed command, on the off chance that another tracker may be working better.
+
+=cut
+
+sub force_reconnect {
+    my MogileFS::Client $self = shift;
+    return $self->{backend}->force_reconnect();
+}
+
 =head2 readonly
 
   $is_readonly = $mogc->readonly

--- a/t/30-disconnect.t
+++ b/t/30-disconnect.t
@@ -1,0 +1,20 @@
+#!/usr/bin/perl -w
+
+use strict;
+use Test::More;
+use MogileFS::Client;
+
+my $obj = bless({
+    backend => bless({
+    }, 'MogileFS::Backend')
+}, 'MogileFS::Client');
+
+isa_ok($obj, 'MogileFS::Client');
+
+$obj->{backend}->{sock_cache} = 'x';
+is($obj->{backend}->{sock_cache}, 'x');
+
+$obj->force_reconnect();
+is($obj->{backend}->{sock_cache}, undef);
+
+done_testing();

--- a/t/30-disconnect.t
+++ b/t/30-disconnect.t
@@ -14,7 +14,7 @@ isa_ok($obj, 'MogileFS::Client');
 $obj->{backend}->{sock_cache} = 'x';
 is($obj->{backend}->{sock_cache}, 'x');
 
-$obj->force_reconnect();
+$obj->force_disconnect();
 is($obj->{backend}->{sock_cache}, undef);
 
 done_testing();


### PR DESCRIPTION
This patch does two things;

When we lose a connection and reconnect, we do so in a strict sequence so that we only ever retry the failed host after trying all the others.  The client also shuffles the list of hosts, so that if there is more than two trackers, clients will use the remaining ones when one fails.

We have found the most of the error responses we receive are caused by a particular tracker going bad in some way.  Usually, losing database access, or another process making the machine OOM.  We thus force a reconnection to a different tracker after every error.
