### PR TITLE
fix force_disconnect test on perl < 5.9.0

### DIFF
--- a/t/30-disconnect.t
+++ b/t/30-disconnect.t
@@ -4,10 +4,8 @@ use strict;
 use Test::More;
 use MogileFS::Client;
 
-my $obj = bless({
-    backend => bless({
-    }, 'MogileFS::Backend')
-}, 'MogileFS::Client');
+my $obj = fields::new('MogileFS::Client');
+$obj->{backend} = fields::new('MogileFS::Backend');
 
 isa_ok($obj, 'MogileFS::Client');
 


### PR DESCRIPTION
This fixes the following test failure on perl 5.8.8:

```
t/30-disconnect.t .. 1/? Not an ARRAY reference at /root/.cpan/build/MogileFS-Client-1.17/blib/lib/MogileFS/Client.pm line 199.
# Tests were run but no plan was declared and done_testing() was not seen.
t/30-disconnect.t .. Dubious, test returned 255 (wstat 65280, 0xff00)
```

MogileFS::Client utilizes the fields pragma for defining objects. Before perl 5.9.0 fields utilized psuedo-hashes for the objects, which are not completely compatible with regular blessed hashes.
