### PR TITLE
Repair perl 5.8 (Centos 5) installed when reported "Not an ARRAY reference"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ perl:
   - "5.10"
   - "5.8.8"
 install:
+  - "cpanm -n IO::WrapTie"
   - "cpanm -n --installdeps ."
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+language: perl
+perl:
+  - "5.18"
+  - "5.16"
+  - "5.14"
+  - "5.12"
+  - "5.10"
+  - "5.8.8"
+install:
+  - "cpanm -n --installdeps ."
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ perl:
   - "5.14"
   - "5.12"
   - "5.10"
-  - "5.8.8"
+  - "5.8"
 install:
-  - "cpanm -n IO::WrapTie"
+  - "cpanm -n IO::WrapTie LWP::Simple"
   - "cpanm -n --installdeps ."
 notifications:
   email: false

--- a/lib/MogileFS/Backend.pm
+++ b/lib/MogileFS/Backend.pm
@@ -225,7 +225,7 @@ sub err {
 }
 
 sub force_disconnect {
-    my MogileFS::Backend $self = shift;
+    my $self = shift;
     undef $self->{sock_cache};
     return;
 }

--- a/lib/MogileFS/Client.pm
+++ b/lib/MogileFS/Client.pm
@@ -195,7 +195,7 @@ failed command, on the off chance that another tracker may be working better.
 =cut
 
 sub force_disconnect {
-    my MogileFS::Client $self = shift;
+    my $self = shift;
     return $self->{backend}->force_disconnect();
 }
 


### PR DESCRIPTION
1. Repair perl 5.8 (Centos 5) installed when reported "Not an ARRAY reference"
2. Added travis-ci test configuration file .travis.yml, automated testing for each version is working properly.
